### PR TITLE
added requirement text file for python packages

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,17 @@
+asgiref==3.5.0
+certifi==2021.10.8
+charset-normalizer==2.0.12
+Django==4.0.2
+faunadb==4.2.0
+future==0.18.2
+h2==2.6.2
+hpack==3.0.0
+hyper==0.7.0
+hyperframe==3.2.0
+idna==3.3
+iso8601==1.0.2
+pytz==2021.3
+requests==2.27.1
+sqlparse==0.4.2
+tzdata==2021.5
+urllib3==1.26.8


### PR DESCRIPTION
some of the dependencies are not listed in the readme , _requirement text file_  solves this error by writing **pip install requirement.txt**